### PR TITLE
Join encoded subject split over multiple lines before decoding

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -1252,6 +1252,9 @@ MailParser.prototype._encodeString = function(value){
  * @returns {String} converted string
  */
 MailParser.prototype._replaceMimeWords = function(value){
+    if (/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g.test(value) && /=\?([^?]+)\?[QqBb]\?[^?]+\?=\s+(?==\?\1+\?[QqBb]\?[^?]+\?=)/g.test(value)){
+        value = value.replace(/\?\=\s+\=\?[^?]+\?[QqBb]\?/g, '')
+    }
     return value.
         replace(/(=\?[^?]+\?[QqBb]\?[^?]+\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]+\?=)/g, "$1"). // join mimeWords
         replace(/\=\?[^?]+\?[QqBb]\?[^?]+\?=/g, (function(a){


### PR DESCRIPTION
When a base64 encoded subject exceeds the SMTP line length, the string is occassionally split onto multiple lines. Many libraries will split on bytes, instead of characters. This example subject:

Subject: GLG: Regulation of Taxi in China - 张一兵

After base64 encoding by .Net, it becomes:

Subject: =?utf-8?B?R0xHOiBSZWd1bGF0aW9uIG9mIFRheGkgaW4gQ2hpbmEgLSDl?=
 =?utf-8?B?vKDkuIDlhbU=?=

Because it is split in the middle of a multi-byte UTF-8 character, the two pieces of the base64 encoded string must be joined first, before decoding.

This is handled correctly by Gmail, Exchange, etc.

This change looks for lines that are split, and if the encoding scheme is the same for each, joins them before decoding.

If the encoding scheme is different, then it does not join. An example of that scenario can be found in Section 8 (Examples) of the RFC http://tools.ietf.org/html/rfc2047
