### PR TITLE
Passes email properties to "attachment" event

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ object. The parameter provided includes file information (`contentType`,
         streamAttachments: true
     }
 
-    mp.on("attachment", function(attachment){
+    mp.on("attachment", function(attachment, mail){
         var output = fs.createWriteStream(attachment.generatedFileName);
         attachment.stream.pipe(output);
     });

--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -331,7 +331,7 @@ MailParser.prototype._processStateHeader = function(line) {
                 }
                 attachment.stream = this._currentNode.stream;
 
-                this.emit("attachment", attachment);
+                this.emit("attachment", attachment, this._currentNode.parentNode);
             } else {
                 this._currentNode.content = undefined;
             }
@@ -519,7 +519,7 @@ MailParser.prototype._processHeaderLine = function(pos) {
             break;
         case "content-location":
             this._currentNode.meta.location = value.toLowerCase();
-            break;            
+            break;
         case "subject":
             this._currentNode.subject = this._encodeString(value);
             break;

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -1292,6 +1292,40 @@ exports["Attachment info"] = {
             test.done();
         });
     },
+
+    "Pass mail node to headers event": function(test){
+        var encodedText = "Content-type: multipart/mixed; boundary=ABC\r\n"+
+                          "Subject: ABCDEF\r\n"+
+                          "\r\n"+
+                          "--ABC\r\n"+
+                              "Content-Type: application/octet-stream\r\n"+
+                              "Content-Transfer-Encoding: base64\r\n"+
+                              "Content-Disposition: attachment\r\n"+
+                              "\r\n"+
+                              "AAECAwQFBg==\r\n"+
+                          "--ABC--",
+            expectedHash = "9aa461e1eca4086f9230aa49c90b0c61",
+            mail = new Buffer(encodedText, "utf-8");
+
+        var mailparser = new MailParser({streamAttachments: true});
+
+        for(var i=0, len = mail.length; i<len; i++){
+            mailparser.write(new Buffer([mail[i]]));
+        }
+
+        test.expect(2);
+
+        mailparser.on("attachment", function(attachment, email){
+            test.equal(email.subject, "ABCDEF");
+        });
+
+        mailparser.end();
+
+        mailparser.on("end", function(mail){
+            test.ok(1, "Done");
+            test.done();
+        });
+    },
     "Detect Content-Type by filename": function(test){
         var encodedText = "Content-type: multipart/mixed; boundary=ABC\r\n"+
                           "\r\n"+


### PR DESCRIPTION
I'd like to set the filenames of the attachments that get downloaded based on the email properties they come from. For example:

```js
var mp = new MailParser({
    streamAttachments: true
}

mp.on("attachment", function(attachment, mail){
    var day = moment(mail.meta.date).format('YYYY-MM-DD')
    var output = fs.createWriteStream(day + '-' + attachment.generatedFileName);
    attachment.stream.pipe(output);
});
```