### PR TITLE
Turn Unicode non-breaking-space into a real space

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -195,7 +195,7 @@ UUEStream.prototype.flush = function(){
 UUEStream.prototype.decode = function(buffer){
     var filename;
 
-    filename = buffer.slice(0, Math.min(buffer.length, 1024)).toString().split(/\s/)[2] || '';
+    filename = buffer.slice(0, Math.min(buffer.length, 1024)).toString().split(/\s/)[2] || '';
     if(!filename){
         return new Buffer(0);
     }
@@ -210,3 +210,4 @@ UUEStream.prototype.decode = function(buffer){
 
     return buffer;
 };
+


### PR DESCRIPTION
This fixes things when serving JS with an encoding other than UTF8. Tiny change.

Also thanks for this library, I really like the simple interface and it solves a groty, nasty problem. I downloaded every message from my Gmail, and I'm testing using that. For the most part (ie, on all but some really unusually-encoded email) it seems to work well!
