### PR TITLE
Take into account `received` and `x-received` headers when determining `date` of the email

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -455,10 +455,11 @@ MailParser.prototype._processHeaderLine = function(pos) {
             this._currentNode.useMIME = true;
             break;
         case "date":
-            this._currentNode.meta.date = new Date(value);
-            if (Object.prototype.toString.call(this._currentNode.meta.date) != "[object Date]" || this._currentNode.meta.date.toString() == "Invalid Date") {
-                this._currentNode.meta.date = datetime.strtotime(value) && new Date(datetime.strtotime(value) * 1000);
-            }
+            this._parseDate(value);
+            break;
+        case "received":
+        case "x-received":
+            this._parseReceived(value);
             break;
         case "to":
             if (this._currentNode.to && this._currentNode.to.length) {
@@ -603,6 +604,91 @@ MailParser.prototype._parseHeaderLineWithParams = function(value) {
 
     return returnValue;
 };
+
+/**
+ * <p>Parses date string</o>
+ *
+ * <p>Receives possible date string in different formats and
+ * transforms it into a JS Date object</p>
+ *
+ * @param {String} value possible date string
+ * @returns {Date|Boolean} date object
+ */
+MailParser.prototype._parseDateString = function(value) {
+    var date;
+
+    date = new Date(value);
+    if (Object.prototype.toString.call(date) != "[object Date]" || date.toString() == "Invalid Date") {
+        date = datetime.strtotime(value);
+        if (date) {
+            date = new Date(date * 1000);
+        }
+    }
+
+    return date;
+}
+
+/**
+ * <p>Parses Received and X-Received header field value</p>
+ *
+ * <p>Pulls received date from the received and x-received header fields and
+ * update current node meta object with this date as long as it's later as the
+ * existing date of the meta object</p>
+ *
+ * <p>Example: <code>by 10.25.25.72 with SMTP id 69csp2404548lfz; Fri, 6 Feb 2015 15:15:32 -0800 (PST)</code>
+ * will become:
+ * </p>
+ *
+ * <pre>new Date('2015-02-06T23:15:32.000Z')</pre>
+ *
+ * @param {String} value Received string
+ * @returns {Date|Boolean} parsed received date
+ */
+MailParser.prototype._parseReceived = function(value) {
+    var receivedDate, splitString;
+    if (!value) {
+        return false;
+    }
+
+    splitString = value.split(';');
+    value = splitString[splitString.length - 1];
+
+    return this._parseDate(value);
+}
+
+/**
+ * <p>Parses Date header field value</p>
+ *
+ * <p>Pulls date from respective header and updates current node meta object
+ * with it as long as it's further in time</p>
+ *
+ * @param {String} value Date string
+ * @returns {Date|Boolean} parsed date header
+ */
+MailParser.prototype._parseDate = function(value) {
+    var date, currentDate;
+    if (!value) {
+        return false;
+    }
+
+    date = this._parseDateString(value);
+    currentDate = this._currentNode.meta.date;
+
+    if (!date) {
+        if (!currentDate) {
+            this._currentNode.meta.date = date;
+        }
+        return date;
+    }
+
+    if (!currentDate) {
+        this._currentNode.meta.date = date;
+    } else if (date > currentDate) {
+        this._currentNode.meta.date = date;
+    }
+
+    return date;
+}
 
 /**
  * <p>Parses a Content-Type header field value</p>

--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -455,7 +455,7 @@ MailParser.prototype._processHeaderLine = function(pos) {
             this._currentNode.useMIME = true;
             break;
         case "date":
-            this._parseDate(value);
+            this._currentNode.meta.date = this._parseDateString(value);
             break;
         case "received":
         case "x-received":
@@ -645,7 +645,7 @@ MailParser.prototype._parseDateString = function(value) {
  * @returns {Date|Boolean} parsed received date
  */
 MailParser.prototype._parseReceived = function(value) {
-    var receivedDate, splitString;
+    var receivedDate, date, splitString;
     if (!value) {
         return false;
     }
@@ -653,38 +653,20 @@ MailParser.prototype._parseReceived = function(value) {
     splitString = value.split(';');
     value = splitString[splitString.length - 1];
 
-    return this._parseDate(value);
-}
-
-/**
- * <p>Parses Date header field value</p>
- *
- * <p>Pulls date from respective header and updates current node meta object
- * with it as long as it's further in time</p>
- *
- * @param {String} value Date string
- * @returns {Date|Boolean} parsed date header
- */
-MailParser.prototype._parseDate = function(value) {
-    var date, currentDate;
-    if (!value) {
-        return false;
-    }
-
     date = this._parseDateString(value);
-    currentDate = this._currentNode.meta.date;
+    receivedDate = this._currentNode.meta.receivedDate;
 
     if (!date) {
-        if (!currentDate) {
-            this._currentNode.meta.date = date;
+        if (!receivedDate) {
+            this._currentNode.meta.receivedDate = date;
         }
         return date;
     }
 
-    if (!currentDate) {
-        this._currentNode.meta.date = date;
-    } else if (date > currentDate) {
-        this._currentNode.meta.date = date;
+    if (!receivedDate) {
+        this._currentNode.meta.receivedDate = date;
+    } else if (date > receivedDate) {
+        this._currentNode.meta.receivedDate = date;
     }
 
     return date;
@@ -1107,6 +1089,10 @@ MailParser.prototype._processMimeTree = function() {
 
     if (this.mimeTree.meta.date) {
         returnValue.date = this.mimeTree.meta.date;
+    }
+
+    if (this.mimeTree.meta.receivedDate) {
+        returnValue.receivedDate = this.mimeTree.meta.receivedDate;
     }
 
     if (this.mailData.attachments.length) {

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -972,6 +972,31 @@ exports["Transfer encoding"] = {
             test.equal(mail.headers.date, undefined);
             test.done();
         });
+    },
+    "Received Headers": function(test){
+        var encodedTest = "Received: by 10.25.25.72 with SMTP id 69csp2404548lfz;\r\n" +
+                          "        Fri, 6 Feb 2015 20:15:32 -0800 (PST)\r\n" +
+                          "X-Received: by 10.194.200.68 with SMTP id jq4mr7518476wjc.128.1423264531879;\r\n" +
+                          "        Fri, 06 Feb 2015 15:15:31 -0800 (PST)\r\n" +
+                          "Received: from mail.formilux.org (flx02.formilux.org. [195.154.117.161])\r\n" +
+                          "        by mx.google.com with ESMTP id wn4si6920692wjc.106.2015.02.06.15.15.31\r\n" +
+                          "        for <test@example.com>;\r\n" +
+                          "        Fri, 06 Feb 2015 15:15:31 -0800 (PST)\r\n" +
+                          "Received: from flx02.formilux.org (flx02.formilux.org [127.0.0.1])\r\n" +
+                          "        by mail.formilux.org (Postfix) with SMTP id 9D262450C77\r\n" +
+                          "        for <test@example.com>; Sat,  7 Feb 2015 00:15:31 +0100 (CET)\r\n" +
+                          "Date: Fri, 6 Feb 2015 16:13:51 -0700 (MST)\r\n" +
+                          "\r\n" +
+                          "1cTW3A==",
+            mail = new Buffer(encodedTest, "utf-8");
+
+        var mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on("end", function(mail){
+            test.ok(mail.date);
+            test.equal(mail.date.toISOString(), "2015-02-07T04:15:32.000Z");
+            test.done();
+        });
     }
 };
 

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -994,7 +994,9 @@ exports["Transfer encoding"] = {
         mailparser.end(mail);
         mailparser.on("end", function(mail){
             test.ok(mail.date);
-            test.equal(mail.date.toISOString(), "2015-02-07T04:15:32.000Z");
+            test.ok(mail.receivedDate);
+            test.equal(mail.date.toISOString(), "2015-02-06T23:13:51.000Z");
+            test.equal(mail.receivedDate.toISOString(), "2015-02-07T04:15:32.000Z");
             test.done();
         });
     }


### PR DESCRIPTION
This is related to issue #108.