### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     "test": "nodeunit test/"
   },
   "main": "./lib/mailparser",
-  "licenses": [{
-    "type": "MIT",
-    "url": "http://github.com/andris9/mailparser/blob/master/LICENSE"
-  }],
+  "license": "MIT",
   "dependencies": {
     "mimelib": "^0.2.19",
     "encoding": "^0.1.11",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/