### PR TITLE
Allow spaces in uuencoded attachment filename

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -195,7 +195,8 @@ UUEStream.prototype.flush = function() {
 UUEStream.prototype.decode = function(buffer) {
     var filename;
 
-    filename = buffer.slice(0, Math.min(buffer.length, 1024)).toString().split(/\s/)[2] || '';
+    var re = /^begin [0-7]{3} (.*)/;
+    filename = buffer.slice(0, Math.min(buffer.length, 1024)).toString().match(re)[1] || '';
     if (!filename) {
         return new Buffer(0);
     }

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -716,8 +716,29 @@ exports["Attachment filename"] = {
             test.equal(mail.attachments && mail.attachments[0] && mail.attachments[0].content && mail.attachments[0].generatedFileName, "hello;world;test.txt");
             test.done();
         });
-    }
+    },
+    "UUE filename with special characters": function(test) {
+        var encodedText = "Content-Type: multipart/mixed; boundary=ABC\r\n" +
+            "\r\n" +
+            "--ABC\r\n" +
+            "Content-Type: application/octet-stream\r\n" +
+            "Content-Transfer-Encoding: uuencode\r\n" +
+            "Content-Disposition: attachment; filename=\"hello ~!@#%.txt\"\r\n" +
+            "\r\n" +
+            "begin 644 hello ~!@#%.txt\r\n" +
+            "#0V%T\r\n" +
+            "`\r\n" +
+            "end\r\n" +
+            "--ABC--",
+            mail = new Buffer(encodedText, "utf-8");
 
+        var mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on("end", function(mail) {
+            test.equal(mail.attachments && mail.attachments[0] && mail.attachments[0].content && mail.attachments[0].generatedFileName, "hello ~!@#%.txt");
+            test.done();
+        });
+    }
 };
 
 exports["Plaintext format"] = {


### PR DESCRIPTION
Passing the incorrect filename to uuencode will result in null being returned instead of the decoded content. When MailParser tries to do something with the content, a TypeError is thrown.