### PR TITLE
Make mailparser rely on mimelib for word decoding

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -1389,11 +1389,7 @@ MailParser.prototype._encodeString = function(value) {
  * @returns {String} converted string
  */
 MailParser.prototype._replaceMimeWords = function(value) {
-    return value.
-    replace(/(=\?[^?]+\?[QqBb]\?[^?]*\?=)\s+(?==\?[^?]+\?[QqBb]\?[^?]*\?=)/g, "$1"). // join mimeWords
-    replace(/\=\?[^?]+\?[QqBb]\?[^?]*\?=/g, (function(a) {
-        return mimelib.decodeMimeWord(a.replace(/\s/g, ''));
-    }).bind(this));
+    return mimelib.parseMimeWords(value);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "main": "./lib/mailparser",
   "license": "MIT",
   "dependencies": {
-    "mimelib": "^0.2.19",
+    "mimelib": "^0.3.0",
     "encoding": "^0.1.11",
     "mime": "^1.3.4",
     "uue": "^3.0.0"

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -369,6 +369,18 @@ exports["Text encodings"] = {
             test.equal(mail.to[0].name, "Keld Jørn Simonsen");
             test.done();
         });
+    },
+    "Split Mime Words": function(test) {
+        var encodedText = "Content-type: text/plain; charset=utf-8\r\n" +
+            "Subject: =?utf-8?B?R0xHOiBSZWd1bGF0aW9uIG9mIFRheGkgaW4gQ2hpbmEgLSDl?= =?utf-8?B?vKDkuIDlhbU=?=\r\n",
+            mail = new Buffer(encodedText, "utf-8");
+
+        var mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on("end", function(mail) {
+            test.equal(mail.subject, "GLG: Regulation of Taxi in China - 张一兵");
+            test.done();
+        });
     }
 };
 


### PR DESCRIPTION
This continues https://github.com/andris9/mimelib/pull/31 and fixes that same bug in mailparser, by just relying on mimelib (requires a new publish in mimelib).

~~However, the methods aren't actually the same (as I have just now noticed) - mailparser's decodeMimeWords also strips spaces (apparently due to a bug in Sparrow?).~~

~~@andris9 Do you want to keep the the custom behaviour here (stripping spaces) and duplicate the code, or make mimelib also strip that space? I added both variants, either just drop the second commit or squash 'em together (or I can do it too).~~

Fixes #89.
