### PR TITLE
Update mailparser.js

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -342,7 +342,7 @@ MailParser.prototype._processStateHeader = function(line) {
 
     // unfold header lines if needed
     if (line.match(/^\s+/) && lastPos >= 0) {
-        this._currentNode.headers[lastPos] += " " + line.trim();
+        this._currentNode.headers[lastPos] += line.subString(1);
     } else {
         this._currentNode.headers.push(line.trim());
         if (lastPos >= 0) {


### PR DESCRIPTION
and "linear-white-space" shoud be ignore when encode
```
field:"=?gb18030?
 B?zfXA8c/O?="
```