### PR TITLE
Fixes the issue of parsing mails with additional plain text

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -1036,13 +1036,27 @@ MailParser.prototype._processMimeTree = function() {
     }
 
     if (this.mailData.text.length) {
-        for (i = 0, len = this.mailData.text.length; i < len; i++) {
-            if (!returnValue.text && this.mailData.text[i].content) {
-                returnValue.text = this.mailData.text[i].content;
-            } else if (this.mailData.text[i].content) {
-                returnValue.text += this.mailData.text[i].content;
-            }
+      var len = this.mailData.text.length;
+      // if we have both html and text, process text till the length of html assuming its alternative for html
+      if (this.mailData.html.length) {
+        len = this.mailData.html.length;
+      }
+      for (i = 0, len; i < len; i++) {
+        if (!returnValue.text && this.mailData.text[i].content) {
+          returnValue.text = this.mailData.text[i].content;
+        } else if (this.mailData.text[i].content) {
+          returnValue.text += this.mailData.text[i].content;
         }
+      }
+      // all remaining text contents if present assumed as additional content and concatenated with html as well as text
+      for (len = this.mailData.text.length; i < len; i++) {
+        if (this.mailData.text[i].content) {
+          // concatenate to both text and html so that text and html are always same content
+          // user should be able to chose any one of them
+          returnValue.text += this.mailData.text[i].content;
+          returnValue.html += this.mailData.text[i].content;
+        }
+      }
     }
 
 

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -1510,6 +1510,24 @@ exports["Advanced nested HTML"] = function(test) {
     });
 };
 
+exports["Additional text"] = function(test) {
+  var mail = fs.readFileSync(__dirname + "/mixed.eml");
+
+  test.expect(2);
+  var mailparser = new MailParser();
+
+  for (var i = 0, len = mail.length; i < len; i++) {
+    mailparser.write(new Buffer([mail[i]]));
+  }
+
+  mailparser.end();
+  mailparser.on("end", function(mail) {
+    test.equal(mail.text, "\nThis e-mail message has been scanned for Viruses and Content and cleared\nGood Morning;\n\n");
+    test.equal(mail.html, "<HTML><HEAD>\n</HEAD><BODY> \n\n<HR>\nThis e-mail message has been scanned for Viruses and Content and cleared\n<HR>\n</BODY></HTML>\nGood Morning;\n\n");
+    test.done();
+  });
+};
+
 exports["MBOX format"] = {
     "Not a mbox": function(test) {
         var encodedText = "Content-Type: text/plain; charset=utf-8\r\n" +

--- a/test/mixed.eml
+++ b/test/mixed.eml
@@ -1,0 +1,37 @@
+Content-Type: multipart/mixed;
+	boundary="--=b73b47c7-75f9-4775-93eb-475a43310901"
+
+
+----=b73b47c7-75f9-4775-93eb-475a43310901
+Content-Type: multipart/alternative;
+	boundary="--=4d3d5f03-fd7a-40f2-ab55-6bd2de649863"
+
+----=4d3d5f03-fd7a-40f2-ab55-6bd2de649863
+Content-Type: text/plain
+Content-Transfer-Encoding: 7bit
+
+
+This e-mail message has been scanned for Viruses and Content and cleared
+
+----=4d3d5f03-fd7a-40f2-ab55-6bd2de649863
+Content-Type: text/html
+Content-Transfer-Encoding: quoted-printable
+
+<HTML><HEAD>
+</HEAD><BODY>=20
+
+<HR>
+This e-mail message has been scanned for Viruses and Content and cleared
+<HR>
+</BODY></HTML>
+
+----=4d3d5f03-fd7a-40f2-ab55-6bd2de649863--
+
+----=b73b47c7-75f9-4775-93eb-475a43310901
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+Good Morning;
+
+
+----=b73b47c7-75f9-4775-93eb-475a43310901--


### PR DESCRIPTION
Most of the times emails are sent with content in both and specified as alternate (reader can use either one). 
However for some cases it's not an alternate view, but additional content, and we need to join the plain and html.