### PR TITLE
Fix decode case where regex does not match

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -196,12 +196,12 @@ UUEStream.prototype.decode = function(buffer) {
     var filename;
 
     var re = /^begin [0-7]{3} (.*)/;
-    filename = buffer.slice(0, Math.min(buffer.length, 1024)).toString().match(re)[1] || '';
+    filename = buffer.slice(0, Math.min(buffer.length, 1024)).toString().match(re) || '';
     if (!filename) {
         return new Buffer(0);
     }
 
-    buffer = uue.decodeFile(buffer.toString('ascii').replace(/\r\n/g, '\n'), filename);
+    buffer = uue.decodeFile(buffer.toString('ascii').replace(/\r\n/g, '\n'), filename[1]);
 
     if (this.charset.toLowerCase() == "binary") {
         // do nothing


### PR DESCRIPTION
We had a case where an attachment buffer did not match the regex provided, causing the import to crash. So instead of taking the [1] item while matching, we check to see if the filename variable exists, and then take the [1] item of the filename when passing to decodeFile function.