### PR TITLE
Fix "high" priority value typo.

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -866,7 +866,7 @@ MailParser.prototype._parsePriority = function(value) {
             case "low":
                 return "low";
             case "urgent":
-            case "hight":
+            case "high":
                 return "high";
         }
     }


### PR DESCRIPTION
It appears that "high" priority value check has a typo. When "high" is used, it is changed to "normal". If "hight" is a specific hack for broken header values found in the wild, this patch would need to be updated to accept "high" properly as well.