### PR TITLE
Traverse mime tree for deep bodies

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -269,6 +269,7 @@ MailParser.prototype._process = function(finalPart) {
 MailParser.prototype._processStateHeader = function(line) {
     var attachment, lastPos = this._currentNode.headers.length - 1,
         textContent = false,
+        rootNode,
         extension;
 
     // Check if the header ends and body starts
@@ -330,8 +331,14 @@ MailParser.prototype._processStateHeader = function(line) {
                     this._currentNode.stream = new Streams.BinaryStream();
                 }
                 attachment.stream = this._currentNode.stream;
+                
+                rootNode = this._currentNode;
+                
+                while (rootNode.parentNode) {
+                    rootNode = rootNode.parentNode;
+                }
 
-                this.emit("attachment", attachment, this._currentNode.parentNode || this._currentNode);
+                this.emit("attachment", attachment, rootNode);
             } else {
                 this._currentNode.content = undefined;
             }


### PR DESCRIPTION
Make sure the "attachment" event callback always gets the root node instead of the parentNode for nested mime nodes.