### PR TITLE
Fix RFC 2231 Content-Disposition issue

### DIFF
--- a/lib/mailparser.js
+++ b/lib/mailparser.js
@@ -797,10 +797,10 @@ MailParser.prototype._detectFilename = function(value) {
 
     if (fileName) {
         parts = fileName.split("'");
-        encoding = parts.shift();
+        encoding = (parts.length > 1) ? parts[0] : "us-ascii";
         name = parts.pop();
         if (name) {
-            return this._replaceMimeWords(this._replaceMimeWords("=?" + (encoding || "us-ascii") + "?Q?" + name.replace(/%/g, "=") + "?="));
+            return this._replaceMimeWords(this._replaceMimeWords("=?" + encoding + "?Q?" + name.replace(/%/g, "=") + "?="));
         }
     }
     return "";

--- a/test/mailparser.js
+++ b/test/mailparser.js
@@ -501,6 +501,24 @@ exports["Attachment filename"] = {
             test.done();
         });
     },
+    "Content-Disposition filename*X": function(test) {
+        var encodedText = "Content-Type: application/octet-stream\r\n" +
+            "Content-Transfer-Encoding: QUOTED-PRINTABLE\r\n" +
+            "Content-Disposition: attachment;\r\n" +
+            "    filename*0=OA;\r\n" +
+            "    filename*1=U;\r\n" +
+            "    filename*2=.txt\r\n" +
+            "\r\n" +
+            "=00=01=02=03=FD=FE=FF",
+            mail = new Buffer(encodedText, "utf-8");
+
+        var mailparser = new MailParser();
+        mailparser.end(mail);
+        mailparser.on("end", function(mail) {
+            test.equal(mail.attachments && mail.attachments[0] && mail.attachments[0].content && mail.attachments[0].fileName, "OAU.txt");
+            test.done();
+        });
+    },
     "Content-Disposition filename*X*": function(test) {
         var encodedText = "Content-Type: application/octet-stream\r\n" +
             "Content-Transfer-Encoding: QUOTED-PRINTABLE\r\n" +


### PR DESCRIPTION
Filenames inside Content-Disposition headers are missing if no encoding is specified